### PR TITLE
 [Patch] Partial fix for GNOME DE and some API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
+cmake_uninstall.cmake
 install_manifest.txt
 build
+*.so
+*.swp
+enums.[c,h]

--- a/src/sni.c
+++ b/src/sni.c
@@ -453,6 +453,8 @@ sni_disconnect () {
     if (auto_activated) {
         deadbeef->conf_set_int ("gtkui.hide_tray_icon", 0);
     }
+    if (icon)
+        g_object_unref(icon);
     return 0;
 }
 

--- a/src/sni.c
+++ b/src/sni.c
@@ -125,9 +125,13 @@ callback_wait_notifier_register (void* ctx) {
             sleep(1);
             sni_loaded = TRUE;
             sni_update_status(-1);
+            deadbeef->log_detailed((DB_plugin_t*)(&plugin), DDB_LOG_LAYER_INFO,
+                                    "%s: %s\n","Status notifier register success", status_notifier_get_id(sni_ctx));
             return;
         }
         if (state == STATUS_NOTIFIER_STATE_FAILED) {
+            deadbeef->log_detailed((DB_plugin_t*)(&plugin), DDB_LOG_LAYER_DEFAULT,
+                                    "%s: %s\n","Status notifier register failed", status_notifier_get_id(sni_ctx));
             return;
         }
     }
@@ -387,7 +391,6 @@ sni_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
         break;
     
     case DB_EV_STOP:
-        g_debug("Event: DB_EV_STOP");
     case DB_EV_SONGFINISHED:
         g_debug("Event: DB_EV_SONGFINISHSED");
         sni_update_status (DDB_PLAYBACK_STATE_STOPPED);
@@ -405,7 +408,7 @@ int
 sni_connect () {
     gtkui_plugin = (ddb_gtkui_t *)deadbeef->plug_get_for_id (DDB_GTKUI_PLUGIN_ID);
     if (!gtkui_plugin) {
-        fprintf (stderr, "sni: can't find gtkui plugin\n");
+        deadbeef->log_detailed((DB_plugin_t*)(&plugin), DDB_LOG_LAYER_DEFAULT, "sni: can't find gtkui plugin\n");
         return -1;
     }
 
@@ -421,7 +424,7 @@ sni_connect () {
     }
 
     if (!toggle_mainwindow_action) {
-        fprintf (stderr, "sni: failed to find \"toggle_player_window\" gtkui plugin\n");
+        deadbeef->log_detailed ((DB_plugin_t*)(&plugin), DDB_LOG_LAYER_DEFAULT, "sni: failed to find \"toggle_player_window\" gtkui plugin\n");
     }
 
     int enabled = deadbeef->conf_get_int ("sni.enabled", 1);
@@ -456,6 +459,7 @@ static const char settings_dlg[] =
 
 static DB_misc_t plugin = {
     .plugin.type = DB_PLUGIN_MISC,
+    .plugin.flags = DDB_PLUGIN_FLAG_LOGGING,
     .plugin.api_vmajor = 1,
     .plugin.api_vminor = 5,
     .plugin.version_major = 1,

--- a/src/sni.c
+++ b/src/sni.c
@@ -71,6 +71,10 @@ on_activate_requested (void) {
             else {
                 gtk_window_present (GTK_WINDOW (mainwin));
             }
+            gtk_window_move(GTK_WINDOW (mainwin),
+                            deadbeef->conf_get_int("mainwin.geometry.x", 0),
+                            deadbeef->conf_get_int("mainwin.geometry.y", 0));
+            
             gdk_x11_window_force_focus (gdk_window, 0);
         }
     }

--- a/src/sni.c
+++ b/src/sni.c
@@ -101,16 +101,24 @@ on_scroll_requested (StatusNotifier *sn,
                      int diff,
                      StatusNotifierScrollOrientation direction)
 {
+    if (deadbeef->conf_get_int("sni.volume_hdirect_ignore", 1))
+        if (direction == STATUS_NOTIFIER_SCROLL_ORIENTATION_HORIZONTAL)
+            return;
+    
+    if (deadbeef->conf_get_int("sni.volume_reverse", 0))
+        diff *= -1;
+
     float vol = deadbeef->volume_get_db ();
     int sens = deadbeef->conf_get_int ("gtkui.tray_volume_sensitivity", 1);
-
-    if (diff > 0) {
-        vol += sens;
+    
+    if (diff) {
+        if (diff > 0) {
+            vol += sens;
+        }
+        else {
+            vol -= sens;
+        }
     }
-    else {
-        vol -= sens;
-    }
-
     if (vol > 0) {
         vol = 0;
     }
@@ -255,7 +263,6 @@ sni_update_tooltip (int state) {
                 
                 gchar title_body[TOOLTIP_MAX_LENGTH];
                 if (tt_plain_text) {
-                    //TODO
                     date ?
                         g_snprintf (title_body, TOOLTIP_MAX_LENGTH, _(TOOLTIP_FORMAT_PLAIN), state == OUTPUT_STATE_PAUSED ? _("Playback paused") : _("Playback played"),
                                    escaped_title  ? escaped_title  : ns,
@@ -506,7 +513,11 @@ static const char settings_dlg[] =
     "property \"Use animated icon (SNI overlay enable)\" checkbox sni.animated 1;\n"
     "property \"Enable SNI tooltip\" checkbox sni.enable_tooltip 1;\n"
     "property \"Use plain text tooltip (if tooltip enabled)\" checkbox sni.tooltip_plain_text 0;\n"
-    "property \"Notifier registration waiting time (sec.)\" entry sni.waiting_sec 60;\n"
+    
+    "property \"Volume control horizontal scroll ignore\" checkbox sni.volume_hdirect_ignore 1;\n"
+    "property \"Volume control use inverse scroll direction\" checkbox sni.volume_reverse 0;\n"
+
+    "property \"Notifier registration waiting time (sec.)\" spinbtn[10,120,5] sni.waiting_sec 60;\n"
 ;
 
 

--- a/src/sni.c
+++ b/src/sni.c
@@ -389,10 +389,17 @@ sni_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
         g_debug("Event: DB_EV_PAUSED");
         sni_update_status (-1);
         break;
-    
+    case DB_EV_SONGCHANGED:
+        {
+            ddb_event_trackchange_t* ev_change = (ddb_event_trackchange_t*)ctx;
+            if (ev_change->to == NULL) {
+                g_debug("Event: DB_EV_SONGCHANGED");
+                sni_update_status (DDB_PLAYBACK_STATE_STOPPED);
+            }
+            break;
+        }
     case DB_EV_STOP:
-    case DB_EV_SONGFINISHED:
-        g_debug("Event: DB_EV_SONGFINISHSED");
+        g_debug("Event: DB_EV_STOP");
         sni_update_status (DDB_PLAYBACK_STATE_STOPPED);
         break;
 

--- a/src/sni.c
+++ b/src/sni.c
@@ -468,7 +468,7 @@ static DB_misc_t plugin = {
     .plugin.type = DB_PLUGIN_MISC,
     .plugin.flags = DDB_PLUGIN_FLAG_LOGGING,
     .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    .plugin.api_vminor = 11,
     .plugin.version_major = 1,
     .plugin.version_minor = 3,
 #if GTK_CHECK_VERSION (3, 0, 0)


### PR DESCRIPTION
Fix "3 dots" bug in GNOME DE. Appindicator now visible and work correctly, but the icon is not updated until the mouse hovers over it. At the moment I do not know how to fix it.
Also redesigned calls to depresated constants and enabled logging API instead of stderr.